### PR TITLE
Reducing boilerplate when including plugin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,15 @@ Add the plugin as a build script dependency:
 ```groovy
 buildscript {
   dependencies {
-    classpath 'com.thefloow:git-version-gradle-plugin:1.0.6'
+    classpath 'com.thefloow:git-version-gradle-plugin:1.0.7'
   }
 }
 ```
 
-Configure the plugin to specify a destination file path and the git directory:
+Optionally override plugin configuration to override destination file path and the git directory:
 ```groovy
 gitVersionPlugin {
-  destinationFile = file("src/main/resources/META-INF/version/git-${group}_${project.name}.properties")
+  destinationFile = file("META-INF/version/git-${project.group}_${project.name}.properties")
   gitDir = file("${rootProject.projectDir}/.git")
 }
 ```

--- a/src/main/groovy/com/thefloow/gradle/gitversion/gradle/GeneratePropertyFileTask.groovy
+++ b/src/main/groovy/com/thefloow/gradle/gitversion/gradle/GeneratePropertyFileTask.groovy
@@ -13,12 +13,16 @@ class GeneratePropertyFileTask extends DefaultTask {
     @TaskAction
     void generateFile() {
 
+        File genDir = new File(project.buildDir, "generated-version-info")
+        File outputFile = new File(genDir, destinationFile().get().path)
+
         File gitDir = project.file(gitDir)
-        File output = project.file(destinationFile)
         String version = project.version
 
-        logger.quiet "Writing git version for git repo: '$gitDir', to: '$output' (project version: '$version')"
+        project.sourceSets.main.output.dir(genDir, builtBy: name)
 
-        new VersionFileGenerator().execute(gitDir, output, version)
+        logger.quiet "Writing git version for git repo: '$gitDir', to: '$outputFile' (project version: '$version')"
+
+        new VersionFileGenerator().execute(gitDir, outputFile, version)
     }
 }

--- a/src/main/groovy/com/thefloow/gradle/gitversion/gradle/GitVersionPlugin.groovy
+++ b/src/main/groovy/com/thefloow/gradle/gitversion/gradle/GitVersionPlugin.groovy
@@ -2,6 +2,7 @@ package com.thefloow.gradle.gitversion.gradle
 
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.plugins.JavaPlugin
 
 class GitVersionPlugin implements Plugin<Project> {
 
@@ -9,10 +10,15 @@ class GitVersionPlugin implements Plugin<Project> {
 
         def extension = project.extensions.create('gitVersionPlugin', GitVersionPluginExtension, project)
 
-        project.tasks.create('generatePropertiesFile', GeneratePropertyFileTask) {
+        def task = project.tasks.create('generatePropertiesFile', GeneratePropertyFileTask) {
             destinationFile = { extension.destinationFile }
             gitDir = { extension.gitDir }
         }
+
+        project.getPlugins().withType(JavaPlugin) {
+                project.tasks.processResources.dependsOn task
+        }
+
     }
 }
 

--- a/src/main/groovy/com/thefloow/gradle/gitversion/gradle/GitVersionPluginExtension.groovy
+++ b/src/main/groovy/com/thefloow/gradle/gitversion/gradle/GitVersionPluginExtension.groovy
@@ -10,6 +10,9 @@ class GitVersionPluginExtension {
 
     GitVersionPluginExtension(Project project) {
         destinationFile = project.objects.property(File)
+        destinationFile.set(new File("META-INF/version/git-${project.group}_${project.name}.properties"))
+
         gitDir = project.objects.property(File)
+        gitDir.set(project.rootProject.file(".git"))
     }
 }


### PR DESCRIPTION
 * Automatically add the 'generate' task as dependency of the 'processResources'.
 * Provide sensible default configuration.
 * Generate files to "${project.buildDir}/generated-version-info" directly rather than 'src/main/resources'